### PR TITLE
fix for load_checkpoint_and_dispatch(device_map=None)

### DIFF
--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -474,7 +474,7 @@ def load_checkpoint_and_dispatch(
         device_map = infer_auto_device_map(
             model, max_memory=max_memory, no_split_module_classes=no_split_module_classes, dtype=dtype
         )
-    if offload_state_dict is None and "disk" in device_map.values():
+    if offload_state_dict is None and device_map is not None and "disk" in device_map.values():
         offload_state_dict = True
     load_checkpoint_in_model(
         model,


### PR DESCRIPTION
The `load_checkpoint_and_dispatch` method has `device_map: Optional[Union[str, Dict[str, Union[int, str, torch.device]]]] = None,`

But if you pass `device_map=None` you get an error:

```
accelerate/big_modeling.py", line 477, in load_checkpoint_and_dispatch
    if offload_state_dict is None and "disk" in device_map.values():
AttributeError: 'NoneType' object has no attribute 'values'
```